### PR TITLE
Iteractive sessions with email notifications and walltime specifier

### DIFF
--- a/src/.bash_functions
+++ b/src/.bash_functions
@@ -143,15 +143,15 @@ is-run() {
     gpus=$([[ $4 =~ ^[0-9]+$ ]]         && echo "$4"                                || echo "")
     other=$([[ ! -z $5 ]]               && echo ":$5"                               || echo "")
     queue=$([[ $gpus -eq 0 ]]           && echo "default@meta-pbs.metacentrum.cz"   || echo "gpu@meta-pbs.metacentrum.cz")
-    mail=$([[ ! -z $IS_MAIL ]]          && echo "-m ${IS_MAIL}"                     || echo "")
+    mail=$([[ ! -z $IS_MAIL ]]          && echo "${IS_MAIL}"                        || echo "n")
     walltime=$([[ ! -z $IS_WALLTIME ]]  && echo "${IS_WALLTIME}"                    || echo "12")
 
-    if [[ -z $cpus ]] || [[ -z $rams ]] || [[ -z $scrt ]] || [[ -z $gpus ]] || [[ ! $mail =~ "^(abe)|(be)|(ae)|(ab)|(e)|(b)|(a)$" ]] || [[ -z $walltime ]]; then
+    if [[ -z $cpus ]] || [[ -z $rams ]] || [[ -z $scrt ]] || [[ -z $gpus ]] || [[ ! $mail =~ ^(abe|be|ae|ab|n|e|b|a)$ ]] || [[ -z $walltime ]]; then
         echo_error -e "[IS_MAIL=a|b|e] [IS_WALLTIME=hh (default 12)] is-run <cpus> <rams-gb> <scrt-gb> <gpus> [cluster|city] \nemail notification options: \033[1;34mhttps://wiki.metacentrum.cz/wiki/About_scheduling_system#How_to_setup_email_notification_about_job_state\033[0m"
         return 1
     fi
 
-    requirements="${mail} -l walltime=${walltime}:00:00 -q ${queue} -l select=1:ncpus=${cpus}:ngpus=${gpus}:mem=${rams}:scratch_ssd=${scrt}${other}"
+    requirements="-m ${mail} -l walltime=${walltime}:00:00 -q ${queue} -l select=1:ncpus=${cpus}:ngpus=${gpus}:mem=${rams}:scratch_ssd=${scrt}${other}"
     is-run-requirements "${requirements}"
 }
 

--- a/src/.bash_functions
+++ b/src/.bash_functions
@@ -147,7 +147,7 @@ is-run() {
     walltime=$([[ ! -z $IS_WALLTIME ]]  && echo "${IS_WALLTIME}"                    || echo "12")
 
     if [[ -z $cpus ]] || [[ -z $rams ]] || [[ -z $scrt ]] || [[ -z $gpus ]] || [[ ! $mail =~ "^(abe)|(be)|(ae)|(ab)|(e)|(b)|(a)$" ]] || [[ -z $walltime ]]; then
-        echo_error -e "[IS_MAIL=a|b|e] [IS_WALLTIME=hh (default 12)] is-run <cpus> <rams-gb> <scrt-gb> <gpus> [cluster|city] \nemail notification legend: \033[1;34mhttps://wiki.metacentrum.cz/wiki/About_scheduling_system#How_to_setup_email_notification_about_job_state\033[0m"
+        echo_error -e "[IS_MAIL=a|b|e] [IS_WALLTIME=hh (default 12)] is-run <cpus> <rams-gb> <scrt-gb> <gpus> [cluster|city] \nemail notification options: \033[1;34mhttps://wiki.metacentrum.cz/wiki/About_scheduling_system#How_to_setup_email_notification_about_job_state\033[0m"
         return 1
     fi
 

--- a/src/.metaenv_user_conf
+++ b/src/.metaenv_user_conf
@@ -11,6 +11,8 @@ VERBOSITY_LEVEL=4
 ENVIRONMENT_VARS=(
     # for example:
     SAMPLE_TEST_VARIABLE="It works!"
+    # IS_MAIL=          # default email notification (possible values `a|b|e` see https://wiki.metacentrum.cz/wiki/About_scheduling_system#How_to_setup_email_notification_about_job_state for more info)
+    # IS_WALLTIME=12    # default walltime in HOURS (you can override using `IS_WALLTIME=42 is-...`)
 )
 
 # Add your favourie software to the PATH variable
@@ -49,3 +51,6 @@ FAVOURITE_IS_CONFIGS=(
     "2 32 32 1"
     "4 16 32 0 plzen=True"
 )
+
+
+


### PR DESCRIPTION
# Iteractive sessions with email notifications and walltime specifier

Walltime and email notification settings can be set using variables `IS_MAIL` and `IS_WALLTIME`.

Default values are
1. `IS_MAIL=n` i.e. no notifications
2. `IS_WALLTIME=12` i.e. 12 hours of interactive sessions walltime

Either you can set your favourite settings globally by setting one of the variables in `ENVIRONMENT_VARS` array in your `.metaenv_user_conf` file or with every `is-run` or `is-...` call.

Some examples:
```sh
(BULLSEYE)fpartl@skirit:~$ is-2-16-32-0-brno-True 
qsub -I -p +250 -m n -l walltime=12:00:00 -q default@meta-pbs.metacentrum.cz -l select=1:ncpus=2:ngpus=0:mem=16gb:scratch_ssd=32gb:brno=True -- /bin/bash -c "export HOME=/storage/brno2/home/fpartl && cd ~ && /bin/bash"... proceed? (y/n):^C
(BULLSEYE)fpartl@skirit:~$ IS_WALLTIME=42 is-2-16-32-0-brno-True 
qsub -I -p +250 -m n -l walltime=42:00:00 -q default@meta-pbs.metacentrum.cz -l select=1:ncpus=2:ngpus=0:mem=16gb:scratch_ssd=32gb:brno=True -- /bin/bash -c "export HOME=/storage/brno2/home/fpartl && cd ~ && /bin/bash"... proceed? (y/n):^C
(BULLSEYE)fpartl@skirit:~$ IS_MAIL=abe is-2-16-32-0-brno-True 
qsub -I -p +250 -m abe -l walltime=12:00:00 -q default@meta-pbs.metacentrum.cz -l select=1:ncpus=2:ngpus=0:mem=16gb:scratch_ssd=32gb:brno=True -- /bin/bash -c "export HOME=/storage/brno2/home/fpartl && cd ~ && /bin/bash"... proceed? (y/n):^C
(BULLSEYE)fpartl@skirit:~$ IS_MAIL=xxx is-2-16-32-0-brno-True 
[IS_MAIL=a|b|e] [IS_WALLTIME=hh (default 12)] is-run <cpus> <rams-gb> <scrt-gb> <gpus> [cluster|city] 
email notification options: https://wiki.metacentrum.cz/wiki/About_scheduling_system#How_to_setup_email_notification_about_job_state
(BULLSEYE)fpartl@skirit:~$ IS_MAIL=abe IS_WALLTIME=37 is-2-16-32-0-brno-True 
qsub -I -p +250 -m abe -l walltime=37:00:00 -q default@meta-pbs.metacentrum.cz -l select=1:ncpus=2:ngpus=0:mem=16gb:scratch_ssd=32gb:brno=True -- /bin/bash -c "export HOME=/storage/brno2/home/fpartl && cd ~ && /bin/bash"... proceed? (y/n):^C
(BULLSEYE)fpartl@skirit:~$
```  